### PR TITLE
Removing firebase TODO from index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,9 +16,6 @@
 
     <!-- The core Firebase JS SDK is always required and must be listed first -->
     <script src="https://www.gstatic.com/firebasejs/7.5.0/firebase-app.js"></script>
-
-    <!-- TODO: Add SDKs for Firebase products that you want to use
-        https://firebase.google.com/docs/web/setup#available-libraries -->
     <script src="https://www.gstatic.com/firebasejs/7.5.0/firebase-analytics.js"></script>
     <script>
       const firebaseConfig = {


### PR DESCRIPTION
We do not need to add any other libraries from firebase, thus removing this stale todo