### PR TITLE
[WIP] Adding toggle for auxillary channel in muse usb port

### DIFF
--- a/src/components/PageSwitcher/PageSwitcher.js
+++ b/src/components/PageSwitcher/PageSwitcher.js
@@ -45,7 +45,7 @@ export function PageSwitcher() {
   const [introData, setIntroData] = useState(emptyChannelData)
   const [heartRawData, setHeartRawData] = useState(emptyChannelData);
   const [heartSpectraData, setHeartSpectraData] = useState(emptySingleChannelData);
-  const [rawData, setRawData] = useState(emptyAuxChannelData);
+  const [rawData, setRawData] = useState(emptyAuxChannelData);;
   const [spectraData, setSpectraData] = useState(emptyChannelData); 
   const [bandsData, setBandsData] = useState(emptyChannelData);
   const [animateData, setAnimateData] = useState(emptyChannelData);

--- a/src/components/PageSwitcher/PageSwitcher.js
+++ b/src/components/PageSwitcher/PageSwitcher.js
@@ -31,11 +31,15 @@ const alpha = translations.types.alpha;
 const ssvep = translations.types.ssvep;
 const predict = translations.types.predict;
 
+const nChans = 4;
+
 export function PageSwitcher() {
 
   // for using Aux channel
   const [enableAux, setEnableAux] = useState(false);
-  const handleToggleEnableAux = useCallback((newChecked) => setEnableAux(newChecked), []);
+  const handleToggleEnableAux = useCallback((newChecked) => {
+    setEnableAux(newChecked);
+  }, []);
 
   // data pulled out of multicast$
   const [introData, setIntroData] = useState(emptyChannelData)

--- a/src/components/PageSwitcher/PageSwitcher.js
+++ b/src/components/PageSwitcher/PageSwitcher.js
@@ -31,16 +31,16 @@ const alpha = translations.types.alpha;
 const ssvep = translations.types.ssvep;
 const predict = translations.types.predict;
 
-const nChans = 4;
-
 export function PageSwitcher() {
-
-  // for using Aux channel
-  const [enableAux, setEnableAux] = useState(false);
-  const handleToggleEnableAux = useCallback((newChecked) => {
-    setEnableAux(newChecked);
-  }, []);
-
+  
+  const [checked, setChecked] = useState(false);
+  const handleChange = useCallback((newChecked) => setChecked(newChecked), []);
+  window.enableAux = checked;
+  if (window.enableAux) {
+    window.nchans = 5;
+  } else {
+    window.nchans = 4;
+  }
   // data pulled out of multicast$
   const [introData, setIntroData] = useState(emptyChannelData)
   const [heartRawData, setHeartRawData] = useState(emptyChannelData);
@@ -58,7 +58,7 @@ export function PageSwitcher() {
   const [introSettings] = useState(funIntro.getSettings);
   const [heartRawSettings] = useState(funHeartRaw.getSettings);
   const [heartSpectraSettings] = useState(funHeartSpectra.getSettings);
-  const [rawSettings, setRawSettings] = useState(funRaw.getSettings(enableAux)); 
+  const [rawSettings, setRawSettings] = useState(funRaw.getSettings); 
   const [spectraSettings, setSpectraSettings] = useState(funSpectra.getSettings); 
   const [bandsSettings, setBandsSettings] = useState(funBands.getSettings);
   const [animateSettings, setAnimateSettings] = useState(funAnimate.getSettings);
@@ -143,7 +143,7 @@ export function PageSwitcher() {
         funHeartSpectra.setup(setHeartSpectraData, heartSpectraSettings);
         break;
       case raw:
-        funRaw.setup(setRawData, rawSettings, enableAux);
+        funRaw.setup(setRawData, rawSettings);
         break;
       case spectra:
         funSpectra.setup(setSpectraData, spectraSettings);
@@ -181,15 +181,13 @@ export function PageSwitcher() {
         window.source = {};
         window.source.connectionStatus = {};
         window.source.connectionStatus.value = true;
-        window.source.eegReadings$ = mockMuseEEG(enableAux);
+        window.source.eegReadings$ = mockMuseEEG(256);
         setStatus(generalTranslations.connectedMock);
       } else {
         // Connect with the Muse EEG Client
         setStatus(generalTranslations.connecting);
         window.source = new MuseClient();
-        if (enableAux) {
-          window.source.enableAux = true;
-        }
+        window.source.enableAux = window.enableAux;
         await window.source.connect();
         await window.source.start();
         window.source.eegReadings$ = window.source.eegReadings;
@@ -265,7 +263,7 @@ export function PageSwitcher() {
       case heartSpectra:
         return <funHeartSpectra.renderModule data={heartSpectraData} />;
       case raw:
-        return <funRaw.renderModule data={rawData} enableAux={enableAux} />;
+        return <funRaw.renderModule data={rawData} />;
       case spectra:
         return <funSpectra.renderModule data={spectraData} />;
       case bands:
@@ -364,8 +362,9 @@ export function PageSwitcher() {
           </ButtonGroup>
         <Checkbox
           label="Enable Muse Auxillary Channel"
-          checked={enableAux}
-          onChange={handleToggleEnableAux}
+          checked={checked}
+          onChange={handleChange}
+          disabled={status !== generalTranslations.connect}
         />
         </Stack>
       </Card>

--- a/src/components/PageSwitcher/PageSwitcher.js
+++ b/src/components/PageSwitcher/PageSwitcher.js
@@ -33,6 +33,10 @@ const predict = translations.types.predict;
 
 export function PageSwitcher() {
 
+  // for using Aux channel
+  const [enableAux, setEnableAux] = useState(false);
+  const handleToggleEnableAux = useCallback((newChecked) => setEnableAux(newChecked), []);
+
   // data pulled out of multicast$
   const [introData, setIntroData] = useState(emptyChannelData)
   const [heartRawData, setHeartRawData] = useState(emptyChannelData);
@@ -50,7 +54,7 @@ export function PageSwitcher() {
   const [introSettings] = useState(funIntro.getSettings);
   const [heartRawSettings] = useState(funHeartRaw.getSettings);
   const [heartSpectraSettings] = useState(funHeartSpectra.getSettings);
-  const [rawSettings, setRawSettings] = useState(funRaw.getSettings); 
+  const [rawSettings, setRawSettings] = useState(funRaw.getSettings(enableAux)); 
   const [spectraSettings, setSpectraSettings] = useState(funSpectra.getSettings); 
   const [bandsSettings, setBandsSettings] = useState(funBands.getSettings);
   const [animateSettings, setAnimateSettings] = useState(funAnimate.getSettings);
@@ -62,9 +66,6 @@ export function PageSwitcher() {
   // connection status
   const [status, setStatus] = useState(generalTranslations.connect);
 
-  // for using Aux channel
-  const [enableAux, setEnableAux] = useState(false);
-  const handleToggleEnableAux = useCallback((newChecked) => setEnableAux(newChecked), []);
 
   // for picking a new module
   const [selected, setSelected] = useState(raw);
@@ -251,7 +252,7 @@ export function PageSwitcher() {
     }
   }
 
-  function renderCharts() {
+  function renderModules() {
     switch (selected) {
       case intro:
         return <funIntro.renderModule data={introData} />;
@@ -260,7 +261,7 @@ export function PageSwitcher() {
       case heartSpectra:
         return <funHeartSpectra.renderModule data={heartSpectraData} />;
       case raw:
-        return <funRaw.renderModule data={rawData} />;
+        return <funRaw.renderModule data={rawData} enableAux={enableAux} />;
       case spectra:
         return <funSpectra.renderModule data={spectraData} />;
       case bands:
@@ -373,7 +374,7 @@ export function PageSwitcher() {
         />
       </Card>
       {pipeSettingsDisplay()}
-      {renderCharts()}
+      {renderModules()}
       {renderRecord()}
     </React.Fragment>
   );

--- a/src/components/PageSwitcher/components/EEGEduRaw/EEGEduRaw.js
+++ b/src/components/PageSwitcher/components/EEGEduRaw/EEGEduRaw.js
@@ -27,7 +27,6 @@ export function getSettings () {
   return {
     cutOffLow: 2,
     cutOffHigh: 20,
-    nbChannels: 5,
     interval: 50,
     srate: 256,
     duration: 1024,
@@ -45,8 +44,9 @@ export function buildPipe(Settings) {
   // Build Pipe
   window.pipeRaw$ = zipSamples(window.source.eegReadings$).pipe(
     bandpassFilter({ 
-      cutoffFrequencies: [Settings.cutOffLow, Settings.cutOffHigh], 
-      nbChannels: Settings.nbChannels }),
+      cutoffFrequencies: [Settings.cutOffLow, Settings.cutOffHigh],
+      nbChannels: window.nchans
+    }),
     epoch({
       duration: Settings.duration,
       interval: Settings.interval,
@@ -67,6 +67,7 @@ export function setup(setData, Settings) {
   if (window.multicastRaw$) {
     window.subscriptionRaw = window.multicastRaw$.subscribe(data => {
       setData(rawData => {
+
         Object.values(rawData).forEach((channel, index) => {
           if (index < window.nchans) {
             channel.datasets[0].data = data.data[index];
@@ -100,7 +101,6 @@ export function setup(setData, Settings) {
 }
 
 export function renderModule(channels) {
-  console.log(window.nchans)
   function renderCharts() {
     return Object.values(channels.data).map((channel, index) => {
       if (index < window.nchans) {

--- a/src/components/PageSwitcher/components/EEGEduRaw/EEGEduRaw.js
+++ b/src/components/PageSwitcher/components/EEGEduRaw/EEGEduRaw.js
@@ -68,20 +68,29 @@ export function setup(setData, Settings) {
     window.subscriptionRaw = window.multicastRaw$.subscribe(data => {
       setData(rawData => {
         Object.values(rawData).forEach((channel, index) => {
-          if (index < 5) {
+          if (index < window.nchans) {
             channel.datasets[0].data = data.data[index];
             channel.xLabels = generateXTics(Settings.srate, Settings.duration);
             channel.datasets[0].qual = standardDeviation(data.data[index])          
           }
         });
 
-        return {
-          ch0: rawData.ch0,
-          ch1: rawData.ch1,
-          ch2: rawData.ch2,
-          ch3: rawData.ch3,
-          ch4: rawData.ch4
-        };
+        if (window.enableAux) {
+          return {
+            ch0: rawData.ch0,
+            ch1: rawData.ch1,
+            ch2: rawData.ch2,
+            ch3: rawData.ch3,
+            ch4: rawData.ch4
+          };
+        } else {
+          return {
+            ch0: rawData.ch0,
+            ch1: rawData.ch1,
+            ch2: rawData.ch2,
+            ch3: rawData.ch3
+          }
+        }
       });
     });
 

--- a/src/components/PageSwitcher/components/EEGEduRaw/EEGEduRaw.js
+++ b/src/components/PageSwitcher/components/EEGEduRaw/EEGEduRaw.js
@@ -92,14 +92,8 @@ export function setup(setData, Settings) {
 
 export function renderModule(channels, enableAux) {
   function renderCharts() {
-    let upto;
-    if (enableAux) {
-      upto = 5;
-    } else {
-      upto = 4;
-    }
     return Object.values(channels.data).map((channel, index) => {
-      if (index < upto) {
+      if (index < 4) {
       const options = {
         ...generalOptions,
         scales: {

--- a/src/components/PageSwitcher/components/EEGEduRaw/EEGEduRaw.js
+++ b/src/components/PageSwitcher/components/EEGEduRaw/EEGEduRaw.js
@@ -90,10 +90,11 @@ export function setup(setData, Settings) {
   }
 }
 
-export function renderModule(channels, enableAux) {
+export function renderModule(channels) {
+  console.log(window.nchans)
   function renderCharts() {
     return Object.values(channels.data).map((channel, index) => {
-      if (index < 4) {
+      if (index < window.nchans) {
       const options = {
         ...generalOptions,
         scales: {

--- a/src/components/PageSwitcher/components/EEGEduRaw/EEGEduRaw.js
+++ b/src/components/PageSwitcher/components/EEGEduRaw/EEGEduRaw.js
@@ -63,35 +63,24 @@ export function buildPipe(Settings) {
 
 export function setup(setData, Settings) {
   console.log("Subscribing to " + Settings.name);
-
   if (window.multicastRaw$) {
     window.subscriptionRaw = window.multicastRaw$.subscribe(data => {
       setData(rawData => {
-
         Object.values(rawData).forEach((channel, index) => {
-          if (index < window.nchans) {
-            channel.datasets[0].data = data.data[index];
-            channel.xLabels = generateXTics(Settings.srate, Settings.duration);
-            channel.datasets[0].qual = standardDeviation(data.data[index])          
-          }
+          channel.datasets[0].data = data.data[index];
+          channel.xLabels = generateXTics(Settings.srate, Settings.duration);
+          channel.datasets[0].qual = standardDeviation(data.data[index])          
         });
 
-        if (window.enableAux) {
-          return {
-            ch0: rawData.ch0,
-            ch1: rawData.ch1,
-            ch2: rawData.ch2,
-            ch3: rawData.ch3,
-            ch4: rawData.ch4
-          };
-        } else {
-          return {
-            ch0: rawData.ch0,
-            ch1: rawData.ch1,
-            ch2: rawData.ch2,
-            ch3: rawData.ch3
-          }
-        }
+
+        return {
+          ch0: rawData.ch0,
+          ch1: rawData.ch1,
+          ch2: rawData.ch2,
+          ch3: rawData.ch3,
+          ch4: rawData.ch4
+        };
+     
       });
     });
 
@@ -104,56 +93,57 @@ export function renderModule(channels) {
   function renderCharts() {
     return Object.values(channels.data).map((channel, index) => {
       if (index < window.nchans) {
-      const options = {
-        ...generalOptions,
-        scales: {
-          xAxes: [
-            {
-              scaleLabel: {
-                ...generalOptions.scales.xAxes[0].scaleLabel,
-                labelString: specificTranslations.xlabel
+        const options = {
+          ...generalOptions,
+          scales: {
+            xAxes: [
+              {
+                scaleLabel: {
+                  ...generalOptions.scales.xAxes[0].scaleLabel,
+                  labelString: specificTranslations.xlabel
+                }
               }
-            }
-          ],
-          yAxes: [
-            {
-              scaleLabel: {
-                ...generalOptions.scales.yAxes[0].scaleLabel,
-                labelString: specificTranslations.ylabel
-              },
-              ticks: {
-                max: 300,
-                min: -300
+            ],
+            yAxes: [
+              {
+                scaleLabel: {
+                  ...generalOptions.scales.yAxes[0].scaleLabel,
+                  labelString: specificTranslations.ylabel
+                },
+                ticks: {
+                  max: 300,
+                  min: -300
+                }
               }
-            }
-          ]
-        },
-        elements: {
-          line: {
-            borderColor: 'rgba(' + channel.datasets[0].qual*10 + ', 128, 128)',
-            fill: false
+            ]
           },
-          point: {
-            radius: 0
+          elements: {
+            line: {
+              borderColor: 'rgba(' + channel.datasets[0].qual*10 + ', 128, 128)',
+              fill: false
+            },
+            point: {
+              radius: 0
+            }
+          },
+          animation: {
+            duration: 0
+          },
+          title: {
+            ...generalOptions.title,
+            text: generalTranslations.channel + channelNames[index] + ' --- SD: ' + channel.datasets[0].qual 
           }
-        },
-        animation: {
-          duration: 0
-        },
-        title: {
-          ...generalOptions.title,
-          text: generalTranslations.channel + channelNames[index] + ' --- SD: ' + channel.datasets[0].qual 
-        }
-      };
+        };
 
-      return (
-        <Card.Section key={"Card_" + index}>
-          <Line key={"Line_" + index} data={channel} options={options} />
-        </Card.Section>
-      );
-    } else {
-      return null
-    }
+        return (
+          <Card.Section key={"Card_" + index}>
+            <Line key={"Line_" + index} data={channel} options={options} />
+          </Card.Section>
+        );
+      } else {
+        return null
+      }
+
     });
   }
 

--- a/src/components/PageSwitcher/components/chartOptions.js
+++ b/src/components/PageSwitcher/components/chartOptions.js
@@ -23,6 +23,24 @@ export const emptyChannelData = {
   }
 };
 
+export const emptyAuxChannelData = {
+  ch0: {
+    datasets: [{}]
+  },
+  ch1: {
+    datasets: [{}]
+  },
+  ch2: {
+    datasets: [{}]
+  },
+  ch3: {
+    datasets: [{}]
+  },
+  ch4: {
+    datasets: [{}]
+  }
+};
+
 export const emptySingleChannelData = {
   ch1: {
     datasets: [{}]

--- a/src/components/PageSwitcher/utils/mockMuseEEG.js
+++ b/src/components/PageSwitcher/utils/mockMuseEEG.js
@@ -1,3 +1,5 @@
+import {customCount} from './chartUtils'
+
 const { interval, from } = require('rxjs');
 const { map, flatMap } = require('rxjs/operators');
 
@@ -9,7 +11,9 @@ const samples = () => {
 
 const transform = (index) => {
  const timestamp = Date.now();
- return from([0,1,2,3,4]).pipe(
+ let chanNums = customCount(0, window.nchans);
+ console.log(chanNums);
+ return from(chanNums).pipe(
   map(electrode => ({
    timestamp,
    electrode,

--- a/src/components/PageSwitcher/utils/mockMuseEEG.js
+++ b/src/components/PageSwitcher/utils/mockMuseEEG.js
@@ -1,6 +1,3 @@
-import { customCount } from "./chartUtils";
-
-
 const { interval, from } = require('rxjs');
 const { map, flatMap } = require('rxjs/operators');
 
@@ -10,15 +7,9 @@ const samples = () => {
   .map(_ => Math.random()).map(function(x) {return x * 100});
 };
 
-const transform = (index, enableAux) => {
+const transform = (index) => {
  const timestamp = Date.now();
- let chans;
- if (enableAux) {
-  chans = customCount(0, 4);
- } else {
-  chans = customCount(0, 3);
- }
- return from(chans).pipe(
+ return from([0,1,2,3,4]).pipe(
   map(electrode => ({
    timestamp,
    electrode,
@@ -28,9 +19,8 @@ const transform = (index, enableAux) => {
  )
 };
 
-export const mockMuseEEG = (enableAux) => {
+export const mockMuseEEG = (sampleRate) => {
  let index = 0;
- let sampleRate = 256;
  return interval(1000 / sampleRate).pipe(
   map(() => index += 1),
   flatMap(transform),

--- a/src/components/PageSwitcher/utils/mockMuseEEG.js
+++ b/src/components/PageSwitcher/utils/mockMuseEEG.js
@@ -1,3 +1,6 @@
+import { customCount } from "./chartUtils";
+
+
 const { interval, from } = require('rxjs');
 const { map, flatMap } = require('rxjs/operators');
 
@@ -7,9 +10,15 @@ const samples = () => {
   .map(_ => Math.random()).map(function(x) {return x * 100});
 };
 
-const transform = (index) => {
+const transform = (index, enableAux) => {
  const timestamp = Date.now();
- return from([0,1,2,3]).pipe(
+ let chans;
+ if (enableAux) {
+  chans = customCount(0, 4);
+ } else {
+  chans = customCount(0, 3);
+ }
+ return from(chans).pipe(
   map(electrode => ({
    timestamp,
    electrode,
@@ -19,8 +28,9 @@ const transform = (index) => {
  )
 };
 
-export const mockMuseEEG = (sampleRate) => {
+export const mockMuseEEG = (enableAux) => {
  let index = 0;
+ let sampleRate = 256;
  return interval(1000 / sampleRate).pipe(
   map(() => index += 1),
   flatMap(transform),

--- a/src/components/PageSwitcher/utils/mockMuseEEG.js
+++ b/src/components/PageSwitcher/utils/mockMuseEEG.js
@@ -11,8 +11,7 @@ const samples = () => {
 
 const transform = (index) => {
  const timestamp = Date.now();
- let chanNums = customCount(0, window.nchans);
- console.log(chanNums);
+ let chanNums = customCount(0, window.nchans-1);
  return from(chanNums).pipe(
   map(electrode => ({
    timestamp,


### PR DESCRIPTION
Adding a checkbox toggle beside the connect buttons for some of the modules. This will turn on or off the subscription in muse-js to the aux, it alters the number of fake channels sent by mockMuseEEG, it alters the processing through neurosity pipes to send an extra channel through, and it plots the aux channel or not. 

if toggle is enabled, it saves aux data into csv, if not, then it keeps current functionality of NaNs

goal is to add to bands, spectra, heart rate modules,? ssvep, evoked, and open/closed, 
any that don't use just a single presellected channel (like animation, bci, intro)
