### PR TITLE
[ready to deploy] Auxillary channel toggle

### DIFF
--- a/src/components/PageSwitcher/PageSwitcher.js
+++ b/src/components/PageSwitcher/PageSwitcher.js
@@ -1,11 +1,11 @@
 import React, { useState, useCallback } from "react";
 import { MuseClient } from "muse-js";
-import { Select, Card, Stack, Button, ButtonGroup } from "@shopify/polaris";
+import { Select, Card, Stack, Button, ButtonGroup, Checkbox } from "@shopify/polaris";
 
 import { mockMuseEEG } from "./utils/mockMuseEEG";
 import * as translations from "./translations/en.json";
 import * as generalTranslations from "./components/translations/en";
-import { emptyChannelData, emptySingleChannelData } from "./components/chartOptions";
+import { emptyChannelData, emptyAuxChannelData, emptySingleChannelData } from "./components/chartOptions";
 
 import * as funIntro from "./components/EEGEduIntro/EEGEduIntro"
 import * as funHeartRaw from "./components/EEGEduHeartRaw/EEGEduHeartRaw"
@@ -35,18 +35,29 @@ const predict = translations.types.predict;
 
 export function PageSwitcher() {
 
+  // For auxEnable settings
+  const [checked, setChecked] = useState(false);
+  const handleChange = useCallback((newChecked) => setChecked(newChecked), []);
+  window.enableAux = checked;
+  if (window.enableAux) {
+    window.nchans = 5;
+  } else {
+    window.nchans = 4;
+  }
+  let showAux = true; // if it is even available to press (to prevent in some modules)
+
   // data pulled out of multicast$
   const [introData, setIntroData] = useState(emptyChannelData)
   const [heartRawData, setHeartRawData] = useState(emptyChannelData);
   const [heartSpectraData, setHeartSpectraData] = useState(emptySingleChannelData);
-  const [rawData, setRawData] = useState(emptyChannelData);
-  const [spectraData, setSpectraData] = useState(emptyChannelData); 
-  const [bandsData, setBandsData] = useState(emptyChannelData);
+  const [rawData, setRawData] = useState(emptyAuxChannelData);
+  const [spectraData, setSpectraData] = useState(emptyAuxChannelData); 
+  const [bandsData, setBandsData] = useState(emptyAuxChannelData);
   const [animateData, setAnimateData] = useState(emptyChannelData);
   const [spectroData, setSpectroData] = useState(emptyChannelData);
-  const [alphaData, setAlphaData] = useState(emptyChannelData);
-  const [ssvepData, setSsvepData] = useState(emptyChannelData);
-  const [evokedData, setEvokedData] = useState(emptyChannelData);
+  const [alphaData, setAlphaData] = useState(emptyAuxChannelData);
+  const [ssvepData, setSsvepData] = useState(emptyAuxChannelData);
+  const [evokedData, setEvokedData] = useState(emptyAuxChannelData);
   const [predictData, setPredictData] = useState(emptyChannelData);
 
   // pipe settings
@@ -97,6 +108,48 @@ export function PageSwitcher() {
   // for popup flag when recording 2nd condition
   const [recordTwoPop, setRecordTwoPop] = useState(false);
   const recordTwoPopChange = useCallback(() => setRecordTwoPop(!recordTwoPop), [recordTwoPop]);
+
+  switch (selected) {
+    case intro:
+      showAux = false;
+      break
+    case heartRaw:
+      showAux = false;
+      break
+    case heartSpectra:
+      showAux = false;
+      break
+    case raw:
+      showAux = true;
+      break
+    case spectra:
+      showAux = true;
+      break
+    case bands: 
+      showAux = true;
+      break
+    case animate: 
+      showAux = false;
+      break
+    case spectro:
+      showAux = false;
+      break
+    case alpha:
+      showAux = true;
+      break
+    case ssvep:
+      showAux = true;
+      break
+    case evoked:
+      showAux = true;
+      break
+    case predict:
+      showAux = false;
+      break
+    default:
+      console.log("Error on showAux");
+  }
+
 
   const chartTypes = [
     { label: intro, value: intro },
@@ -188,6 +241,7 @@ export function PageSwitcher() {
         // Connect with the Muse EEG Client
         setStatus(generalTranslations.connecting);
         window.source = new MuseClient();
+        window.source.enableAux = window.enableAux;
         await window.source.connect();
         await window.source.start();
         window.source.eegReadings$ = window.source.eegReadings;
@@ -256,7 +310,7 @@ export function PageSwitcher() {
     }
   }
 
-  function renderCharts() {
+  function renderModules() {
     switch (selected) {
       case intro:
         return <funIntro.renderModule data={introData} />;
@@ -368,6 +422,12 @@ export function PageSwitcher() {
               {generalTranslations.disconnect}
             </Button>     
           </ButtonGroup>
+          <Checkbox
+            label="Enable Muse Auxillary Channel"
+            checked={checked}
+            onChange={handleChange}
+            disabled={!showAux || status !== generalTranslations.connect}
+          />
         </Stack>
       </Card>
       <Card title={translations.title} sectioned>
@@ -379,7 +439,7 @@ export function PageSwitcher() {
         />
       </Card>
       {pipeSettingsDisplay()}
-      {renderCharts()}
+      {renderModules()}
       {renderRecord()}
     </React.Fragment>
   );

--- a/src/components/PageSwitcher/PageSwitcher.js
+++ b/src/components/PageSwitcher/PageSwitcher.js
@@ -5,7 +5,7 @@ import { Select, Card, Stack, Button, ButtonGroup, Checkbox } from "@shopify/pol
 import { mockMuseEEG } from "./utils/mockMuseEEG";
 import * as translations from "./translations/en.json";
 import * as generalTranslations from "./components/translations/en";
-import { emptyChannelData, emptyAuxChannelData, emptySingleChannelData } from "./components/chartOptions";
+import { emptyAuxChannelData } from "./components/chartOptions";
 
 import * as funIntro from "./components/EEGEduIntro/EEGEduIntro"
 import * as funHeartRaw from "./components/EEGEduHeartRaw/EEGEduHeartRaw"
@@ -47,18 +47,18 @@ export function PageSwitcher() {
   let showAux = true; // if it is even available to press (to prevent in some modules)
 
   // data pulled out of multicast$
-  const [introData, setIntroData] = useState(emptyChannelData)
-  const [heartRawData, setHeartRawData] = useState(emptyChannelData);
-  const [heartSpectraData, setHeartSpectraData] = useState(emptySingleChannelData);
+  const [introData, setIntroData] = useState(emptyAuxChannelData)
+  const [heartRawData, setHeartRawData] = useState(emptyAuxChannelData);
+  const [heartSpectraData, setHeartSpectraData] = useState(emptyAuxChannelData);
   const [rawData, setRawData] = useState(emptyAuxChannelData);
   const [spectraData, setSpectraData] = useState(emptyAuxChannelData); 
   const [bandsData, setBandsData] = useState(emptyAuxChannelData);
-  const [animateData, setAnimateData] = useState(emptyChannelData);
-  const [spectroData, setSpectroData] = useState(emptyChannelData);
+  const [animateData, setAnimateData] = useState(emptyAuxChannelData);
+  const [spectroData, setSpectroData] = useState(emptyAuxChannelData);
   const [alphaData, setAlphaData] = useState(emptyAuxChannelData);
   const [ssvepData, setSsvepData] = useState(emptyAuxChannelData);
   const [evokedData, setEvokedData] = useState(emptyAuxChannelData);
-  const [predictData, setPredictData] = useState(emptyChannelData);
+  const [predictData, setPredictData] = useState(emptyAuxChannelData);
 
   // pipe settings
   const [introSettings] = useState(funIntro.getSettings);

--- a/src/components/PageSwitcher/components/EEGEduAlpha/EEGEduAlpha.js
+++ b/src/components/PageSwitcher/components/EEGEduAlpha/EEGEduAlpha.js
@@ -30,7 +30,6 @@ export function getSettings() {
   return {
     cutOffLow: 2,
     cutOffHigh: 20,
-    nbChannels: 4,
     interval: 100,
     bins: 256,
     sliceFFTLow: 1,
@@ -53,7 +52,7 @@ export function buildPipe(Settings) {
   window.pipeAlpha$ = zipSamples(window.source.eegReadings$).pipe(
     bandpassFilter({ 
       cutoffFrequencies: [Settings.cutOffLow, Settings.cutOffHigh], 
-      nbChannels: Settings.nbChannels }),
+      nbChannels: window.nchans }),
     epoch({
       duration: Settings.duration,
       interval: Settings.interval,
@@ -78,17 +77,16 @@ export function setup(setData, Settings) {
     window.subscriptionAlpha = window.multicastAlpha$.subscribe(data => {
       setData(alphaData => {
         Object.values(alphaData).forEach((channel, index) => {
-          if (index < 4) {
-            channel.datasets[0].data = data.psd[index];
-            channel.xLabels = data.freqs;
-          }
+          channel.datasets[0].data = data.psd[index];
+          channel.xLabels = data.freqs;
         });
 
         return {
           ch0: alphaData.ch0,
           ch1: alphaData.ch1,
           ch2: alphaData.ch2,
-          ch3: alphaData.ch3
+          ch3: alphaData.ch3,
+          ch4: alphaData.ch4
         };
       });
     });
@@ -101,6 +99,7 @@ export function setup(setData, Settings) {
 export function renderModule(channels) {
   function renderCharts() {
     return Object.values(channels.data).map((channel, index) => {
+      if (index === 0) {
       const options = {
         ...generalOptions,
         scales: {
@@ -136,7 +135,6 @@ export function renderModule(channels) {
         }
       };
 
-      if (index === 0) {
         return (
           <Card.Section key={"Card_" + index}>
             <Line key={"Line_" + index} data={channel} options={options} />

--- a/src/components/PageSwitcher/components/EEGEduAnimate/EEGEduAnimate.js
+++ b/src/components/PageSwitcher/components/EEGEduAnimate/EEGEduAnimate.js
@@ -32,7 +32,6 @@ export function getSettings () {
   return {
     cutOffLow: 2,
     cutOffHigh: 20,
-    nbChannels: 4,
     interval: 16,
     bins: 256,
     duration: 128,
@@ -52,7 +51,7 @@ export function buildPipe(Settings) {
   window.pipeAnimate$ = zipSamples(window.source.eegReadings$).pipe(
     bandpassFilter({ 
       cutoffFrequencies: [Settings.cutOffLow, Settings.cutOffHigh], 
-      nbChannels: Settings.nbChannels }),
+      nbChannels: window.nchans }),
     epoch({
       duration: Settings.duration,
       interval: Settings.interval,
@@ -76,7 +75,6 @@ export function setup(setData, Settings) {
     window.subscriptionAnimate = window.multicastAnimate$.subscribe(data => {
       setData(animateData => {
         Object.values(animateData).forEach((channel, index) => {
-          if (index < 4) {
             channel.datasets[0].data = [
               data.delta[index],
               data.theta[index],
@@ -85,14 +83,14 @@ export function setup(setData, Settings) {
               data.gamma[index]
             ];
             channel.xLabels = bandLabels;
-          }
         });
 
         return {
           ch0: animateData.ch0,
           ch1: animateData.ch1,
           ch2: animateData.ch2,
-          ch3: animateData.ch3
+          ch3: animateData.ch3,
+          ch4: animateData.ch4
         };
       });
     });
@@ -129,14 +127,15 @@ export function renderModule(channels) {
     }, []);
 
     return Object.values(channels.data).map((channel, index) => {
-      // console.log(channel) 
       if (channel.datasets[0].data) {
-        // console.log( channel.datasets[0].data[2])
-        window.delta = channel.datasets[0].data[0];
-        window.theta = channel.datasets[0].data[1];
-        window.alpha = channel.datasets[0].data[2];
-        window.beta  = channel.datasets[0].data[3];
-        window.gamma = channel.datasets[0].data[4];
+        if (index === 1) {
+          // console.log( channel.datasets[0].data[2])
+          window.delta = channel.datasets[0].data[0];
+          window.theta = channel.datasets[0].data[1];
+          window.alpha = channel.datasets[0].data[2];
+          window.beta  = channel.datasets[0].data[3];
+          window.gamma = channel.datasets[0].data[4];
+        }
       }   
 
       let thisSketch = sketchTone;

--- a/src/components/PageSwitcher/components/EEGEduEvoked/EEGEduEvoked.js
+++ b/src/components/PageSwitcher/components/EEGEduEvoked/EEGEduEvoked.js
@@ -28,7 +28,6 @@ export function getSettings () {
   return {
     cutOffLow: 2,
     cutOffHigh: 20,
-    nbChannels: 4,
     interval: 1,
     srate: 256,
     duration: 1,
@@ -47,7 +46,7 @@ export function buildPipe(Settings) {
   window.pipeEvoked$ = zipSamples(window.source.eegReadings$).pipe(
     bandpassFilter({ 
       cutoffFrequencies: [Settings.cutOffLow, Settings.cutOffHigh], 
-      nbChannels: Settings.nbChannels }),
+      nbChannels: window.nchans }),
     epoch({
       duration: Settings.duration,
       interval: Settings.interval,
@@ -69,18 +68,18 @@ export function setup(setData, Settings) {
     window.subscriptionEvoked = window.multicastEvoked$.subscribe(data => {
       setData(evokedData => {
         Object.values(evokedData).forEach((channel, index) => {
-          if (index < 4) {
-            channel.datasets[0].data = data.data[index];
-            channel.xLabels = generateXTics(Settings.srate, Settings.duration);
-            channel.datasets[0].qual = standardDeviation(data.data[index])          
-          }
+          channel.datasets[0].data = data.data[index];
+          channel.xLabels = generateXTics(Settings.srate, Settings.duration);
+          channel.datasets[0].qual = standardDeviation(data.data[index])          
         });
 
         return {
           ch0: evokedData.ch0,
           ch1: evokedData.ch1,
           ch2: evokedData.ch2,
-          ch3: evokedData.ch3
+          ch3: evokedData.ch3,
+          ch4: evokedData.ch4
+
         };
       });
     });

--- a/src/components/PageSwitcher/components/EEGEduHeartRaw/EEGEduHeartRaw.js
+++ b/src/components/PageSwitcher/components/EEGEduHeartRaw/EEGEduHeartRaw.js
@@ -24,7 +24,6 @@ export function getSettings () {
   return {
     cutOffLow: 2,
     cutOffHigh: 20,
-    nbChannels: 4,
     interval: 50,
     srate: 256,
     duration: 1024,
@@ -43,7 +42,7 @@ export function buildPipe(Settings) {
   window.pipeHeartRaw$ = zipSamples(window.source.eegReadings$).pipe(
     bandpassFilter({ 
       cutoffFrequencies: [Settings.cutOffLow, Settings.cutOffHigh], 
-      nbChannels: Settings.nbChannels }),
+      nbChannels: window.nchans }),
     epoch({
       duration: Settings.duration,
       interval: Settings.interval,
@@ -65,18 +64,17 @@ export function setup(setData, Settings) {
     window.subscriptionHeartRaw = window.multicastHeartRaw$.subscribe(data => {
       setData(heartRawData => {
         Object.values(heartRawData).forEach((channel, index) => {
-          if (index < 4) {
             channel.datasets[0].data = data.data[index];
             channel.xLabels = generateXTics(Settings.srate, Settings.duration);
             channel.datasets[0].qual = standardDeviation(data.data[index])          
-          }
         });
 
         return {
           ch0: heartRawData.ch0,
           ch1: heartRawData.ch1,
           ch2: heartRawData.ch2,
-          ch3: heartRawData.ch3
+          ch3: heartRawData.ch3,
+          ch4: heartRawData.ch4
         };
       });
     });
@@ -89,49 +87,49 @@ export function setup(setData, Settings) {
 export function renderModule(channels) {
   function renderCharts() {
     return Object.values(channels.data).map((channel, index) => {
-      const options = {
-        ...generalOptions,
-        scales: {
-          xAxes: [
-            {
-              scaleLabel: {
-                ...generalOptions.scales.xAxes[0].scaleLabel,
-                labelString: specificTranslations.xlabel
-              }
-            }
-          ],
-          yAxes: [
-            {
-              scaleLabel: {
-                ...generalOptions.scales.yAxes[0].scaleLabel,
-                labelString: specificTranslations.ylabel
-              },
-              ticks: {
-                max: 300,
-                min: -300
-              }
-            }
-          ]
-        },
-        elements: {
-          line: {
-            borderColor: 'rgba(' + channel.datasets[0].qual + ', 128, 128)',
-            fill: false
-          },
-          point: {
-            radius: 0
-          }
-        },
-        animation: {
-          duration: 0
-        },
-        title: {
-          ...generalOptions.title,
-          text: generalTranslations.channel + channelNames[index] + ' --- SD: ' + channel.datasets[0].qual 
-        }
-      };
-
       if (index === 1) {
+        const options = {
+          ...generalOptions,
+          scales: {
+            xAxes: [
+              {
+                scaleLabel: {
+                  ...generalOptions.scales.xAxes[0].scaleLabel,
+                  labelString: specificTranslations.xlabel
+                }
+              }
+            ],
+            yAxes: [
+              {
+                scaleLabel: {
+                  ...generalOptions.scales.yAxes[0].scaleLabel,
+                  labelString: specificTranslations.ylabel
+                },
+                ticks: {
+                  max: 300,
+                  min: -300
+                }
+              }
+            ]
+          },
+          elements: {
+            line: {
+              borderColor: 'rgba(' + channel.datasets[0].qual + ', 128, 128)',
+              fill: false
+            },
+            point: {
+              radius: 0
+            }
+          },
+          animation: {
+            duration: 0
+          },
+          title: {
+            ...generalOptions.title,
+            text: generalTranslations.channel + channelNames[index] + ' --- SD: ' + channel.datasets[0].qual 
+          }
+        };
+
         return (
           <Card.Section key={"Card_" + index}>
             <Line key={"Line_" + index} data={channel} options={options} />

--- a/src/components/PageSwitcher/components/EEGEduHeartSpectra/EEGEduHeartSpectra.js
+++ b/src/components/PageSwitcher/components/EEGEduHeartSpectra/EEGEduHeartSpectra.js
@@ -27,7 +27,6 @@ export function getSettings() {
   return {
     cutOffLow: .01,
     cutOffHigh: 20,
-    nbChannels: 4,
     interval: 100,
     bins: 8192,
     sliceFFTLow: 0.6,
@@ -50,7 +49,7 @@ export function buildPipe(Settings) {
   window.pipeHeartSpectra$ = zipSamples(window.source.eegReadings$).pipe(
     bandpassFilter({ 
       cutoffFrequencies: [Settings.cutOffLow, Settings.cutOffHigh], 
-      nbChannels: Settings.nbChannels }),
+      nbChannels: window.nchans }),
     epoch({
       duration: Settings.duration,
       interval: Settings.interval,
@@ -125,7 +124,7 @@ export function renderModule(channels) {
           title: {
             ...generalOptions.title,
             text: generalTranslations.channel + 
-              channelNames[index] + 
+              channelNames[1] + 
               " - Estimated HR: " +
               channel.peakF + " BPM"
           }

--- a/src/components/PageSwitcher/components/EEGEduIntro/EEGEduIntro.js
+++ b/src/components/PageSwitcher/components/EEGEduIntro/EEGEduIntro.js
@@ -24,7 +24,6 @@ export function getSettings () {
     name: "Intro",
     cutOffLow: 2,
     cutOffHigh: 20,
-    nbChannels: 4,
     interval: 2,
     srate: 256,
     duration: 512
@@ -42,7 +41,7 @@ export function buildPipe(Settings) {
  window.pipeIntro$ = zipSamples(window.source.eegReadings$).pipe(
     bandpassFilter({ 
       cutoffFrequencies: [Settings.cutOffLow, Settings.cutOffHigh], 
-      nbChannels: Settings.nbChannels }),
+      nbChannels: window.nchans }),
     epoch({
       duration: Settings.duration,
       interval: Settings.interval,
@@ -72,10 +71,7 @@ export function setup(setData, Settings) {
         });
 
         return {
-          ch0: introData.ch0,
-          ch1: introData.ch1,
-          ch2: introData.ch2,
-          ch3: introData.ch3
+          ch0: introData.ch0
         };
       });
     });

--- a/src/components/PageSwitcher/components/EEGEduPredict/EEGEduPredict.js
+++ b/src/components/PageSwitcher/components/EEGEduPredict/EEGEduPredict.js
@@ -30,7 +30,6 @@ export function getSettings() {
   return {
     cutOffLow: 2,
     cutOffHigh: 20,
-    nbChannels: 4,
     interval: 256,
     bins: 256,
     sliceFFTLow: 1,
@@ -52,7 +51,7 @@ export function buildPipe(Settings) {
   window.pipePredict$ = zipSamples(window.source.eegReadings$).pipe(
     bandpassFilter({ 
       cutoffFrequencies: [Settings.cutOffLow, Settings.cutOffHigh], 
-      nbChannels: Settings.nbChannels }),
+      nbChannels: window.nchans }),
     epoch({
       duration: Settings.duration,
       interval: Settings.interval,
@@ -77,17 +76,16 @@ export function setup(setData, Settings) {
     window.subscriptionPredict = window.multicastPredict$.subscribe(data => {
       setData(predictData => {
         Object.values(predictData).forEach((channel, index) => {
-          if (index < 4) {
-            channel.datasets[0].data = data.psd[index];
-            channel.xLabels = data.freqs;
-          }
+          channel.datasets[0].data = data.psd[index];
+          channel.xLabels = data.freqs;      
         });
 
         return {
           ch0: predictData.ch0,
           ch1: predictData.ch1,
           ch2: predictData.ch2,
-          ch3: predictData.ch3
+          ch3: predictData.ch3,
+          ch4: predictData.ch4
         };
       });
     });

--- a/src/components/PageSwitcher/components/EEGEduRaw/EEGEduRaw.js
+++ b/src/components/PageSwitcher/components/EEGEduRaw/EEGEduRaw.js
@@ -27,7 +27,6 @@ export function getSettings () {
   return {
     cutOffLow: 2,
     cutOffHigh: 20,
-    nbChannels: 4,
     interval: 50,
     srate: 256,
     duration: 1024,
@@ -46,7 +45,7 @@ export function buildPipe(Settings) {
   window.pipeRaw$ = zipSamples(window.source.eegReadings$).pipe(
     bandpassFilter({ 
       cutoffFrequencies: [Settings.cutOffLow, Settings.cutOffHigh], 
-      nbChannels: Settings.nbChannels }),
+      nbChannels: window.nchans }),
     epoch({
       duration: Settings.duration,
       interval: Settings.interval,
@@ -68,18 +67,17 @@ export function setup(setData, Settings) {
     window.subscriptionRaw = window.multicastRaw$.subscribe(data => {
       setData(rawData => {
         Object.values(rawData).forEach((channel, index) => {
-          if (index < 4) {
             channel.datasets[0].data = data.data[index];
             channel.xLabels = generateXTics(Settings.srate, Settings.duration);
             channel.datasets[0].qual = standardDeviation(data.data[index])          
-          }
         });
 
         return {
           ch0: rawData.ch0,
           ch1: rawData.ch1,
           ch2: rawData.ch2,
-          ch3: rawData.ch3
+          ch3: rawData.ch3,
+          ch4: rawData.ch4
         };
       });
     });
@@ -92,53 +90,57 @@ export function setup(setData, Settings) {
 export function renderModule(channels) {
   function renderCharts() {
     return Object.values(channels.data).map((channel, index) => {
-      const options = {
-        ...generalOptions,
-        scales: {
-          xAxes: [
-            {
-              scaleLabel: {
-                ...generalOptions.scales.xAxes[0].scaleLabel,
-                labelString: specificTranslations.xlabel
+      if (index < window.nchans) {
+        const options = {
+          ...generalOptions,
+          scales: {
+            xAxes: [
+              {
+                scaleLabel: {
+                  ...generalOptions.scales.xAxes[0].scaleLabel,
+                  labelString: specificTranslations.xlabel
+                }
               }
-            }
-          ],
-          yAxes: [
-            {
-              scaleLabel: {
-                ...generalOptions.scales.yAxes[0].scaleLabel,
-                labelString: specificTranslations.ylabel
-              },
-              ticks: {
-                max: 300,
-                min: -300
+            ],
+            yAxes: [
+              {
+                scaleLabel: {
+                  ...generalOptions.scales.yAxes[0].scaleLabel,
+                  labelString: specificTranslations.ylabel
+                },
+                ticks: {
+                  max: 300,
+                  min: -300
+                }
               }
-            }
-          ]
-        },
-        elements: {
-          line: {
-            borderColor: 'rgba(' + channel.datasets[0].qual*10 + ', 128, 128)',
-            fill: false
+            ]
           },
-          point: {
-            radius: 0
+          elements: {
+            line: {
+              borderColor: 'rgba(' + channel.datasets[0].qual*10 + ', 128, 128)',
+              fill: false
+            },
+            point: {
+              radius: 0
+            }
+          },
+          animation: {
+            duration: 0
+          },
+          title: {
+            ...generalOptions.title,
+            text: generalTranslations.channel + channelNames[index] + ' --- SD: ' + channel.datasets[0].qual 
           }
-        },
-        animation: {
-          duration: 0
-        },
-        title: {
-          ...generalOptions.title,
-          text: generalTranslations.channel + channelNames[index] + ' --- SD: ' + channel.datasets[0].qual 
-        }
-      };
+        };
 
-      return (
-        <Card.Section key={"Card_" + index}>
-          <Line key={"Line_" + index} data={channel} options={options} />
-        </Card.Section>
-      );
+        return (
+          <Card.Section key={"Card_" + index}>
+            <Line key={"Line_" + index} data={channel} options={options} />
+          </Card.Section>
+        );
+      } else {
+        return null
+      }
     });
   }
 

--- a/src/components/PageSwitcher/components/EEGEduSpectro/EEGEduSpectro.js
+++ b/src/components/PageSwitcher/components/EEGEduSpectro/EEGEduSpectro.js
@@ -26,7 +26,6 @@ export function getSettings () {
   return {
     cutOffLow: 1,
     cutOffHigh: 100,
-    nbChannels: 4,
     interval: 16,
     bins: 128,
     duration: 128,
@@ -48,7 +47,7 @@ export function buildPipe(Settings) {
   window.pipeSpectro$ = zipSamples(window.source.eegReadings$).pipe(
     bandpassFilter({ 
       cutoffFrequencies: [Settings.cutOffLow, Settings.cutOffHigh], 
-      nbChannels: Settings.nbChannels }),
+      nbChannels: window.nchans }),
     epoch({
       duration: Settings.duration,
       interval: Settings.interval,
@@ -72,17 +71,16 @@ export function setup(setData, Settings) {
     window.subscriptionSpectro = window.multicastSpectro$.subscribe(data => {
       setData(spectroData => {
         Object.values(spectroData).forEach((channel, index) => {
-          if (index < 4) {
-            channel.datasets[0].data = data.psd[index];
-            channel.xLabels = data.freqs
-          }
+          channel.datasets[0].data = data.psd[index];
+          channel.xLabels = data.freqs
         });
 
         return {
           ch0: spectroData.ch0,
           ch1: spectroData.ch1,
           ch2: spectroData.ch2,
-          ch3: spectroData.ch3
+          ch3: spectroData.ch3,
+          ch4: spectroData.ch4
         };
       });
     });

--- a/src/components/PageSwitcher/components/EEGEduSsvep/EEGEduSsvep.js
+++ b/src/components/PageSwitcher/components/EEGEduSsvep/EEGEduSsvep.js
@@ -31,7 +31,6 @@ export function getSettings() {
   return {
     cutOffLow: 2,
     cutOffHigh: 20,
-    nbChannels: 4,
     interval: 100,
     bins: 256,
     sliceFFTLow: 1,
@@ -53,7 +52,7 @@ export function buildPipe(Settings) {
   window.pipeSsvep$ = zipSamples(window.source.eegReadings$).pipe(
     bandpassFilter({ 
       cutoffFrequencies: [Settings.cutOffLow, Settings.cutOffHigh], 
-      nbChannels: Settings.nbChannels }),
+      nbChannels: window.nchans }),
     epoch({
       duration: Settings.duration,
       interval: Settings.interval,
@@ -78,17 +77,17 @@ export function setup(setData, Settings) {
     window.subscriptionSsvep = window.multicastSsvep$.subscribe(data => {
       setData(ssvepData => {
         Object.values(ssvepData).forEach((channel, index) => {
-          if (index < 4) {
-            channel.datasets[0].data = data.psd[index];
-            channel.xLabels = data.freqs;
-          }
+          channel.datasets[0].data = data.psd[index];
+          channel.xLabels = data.freqs;
+  
         });
 
         return {
           ch0: ssvepData.ch0,
           ch1: ssvepData.ch1,
           ch2: ssvepData.ch2,
-          ch3: ssvepData.ch3
+          ch3: ssvepData.ch3,
+          ch4: ssvepData.ch4
         };
       });
     });

--- a/src/components/PageSwitcher/components/chartOptions.js
+++ b/src/components/PageSwitcher/components/chartOptions.js
@@ -23,6 +23,24 @@ export const emptyChannelData = {
   }
 };
 
+export const emptyAuxChannelData = {
+  ch0: {
+    datasets: [{}]
+  },
+  ch1: {
+    datasets: [{}]
+  },
+  ch2: {
+    datasets: [{}]
+  },
+  ch3: {
+    datasets: [{}]
+  },
+  ch4: {
+    datasets: [{}]
+  }
+};
+
 export const emptySingleChannelData = {
   ch1: {
     datasets: [{}]

--- a/src/components/PageSwitcher/utils/mockMuseEEG.js
+++ b/src/components/PageSwitcher/utils/mockMuseEEG.js
@@ -1,3 +1,5 @@
+import { customCount } from './chartUtils'
+
 const { interval, from } = require('rxjs');
 const { map, flatMap } = require('rxjs/operators');
 
@@ -9,7 +11,8 @@ const samples = () => {
 
 const transform = (index) => {
  const timestamp = Date.now();
- return from([0,1,2,3]).pipe(
+ let chanNums = customCount(0, window.nchans-1);
+ return from(chanNums).pipe(
   map(electrode => ({
    timestamp,
    electrode,


### PR DESCRIPTION
Adding a checkbox toggle beside the connect buttons for some of the modules. This will turn on or off the subscription in muse-js to the aux, it alters the number of fake channels sent by mockMuseEEG, it alters the processing through neurosity pipes to send an extra channel through, and it plots the aux channel or not.

if toggle is enabled, it saves aux data into csv, if not, then it keeps current functionality of NaNs

added to bands, spectra, heart rate modules, ssvep, evoked, and open/closed,
any that don't use just a single preselected channel (like animation, bci, intro)
